### PR TITLE
[고도화] MySQL -> PostgreSQL

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,11 +9,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/board
-    username: ryu
+    url: jdbc:postgresql://localhost:5432/board
+    username: postgres
     password: thisisTESTpw!#%&
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
   jpa:
     open-in-view: true
     defer-datasource-initialization: true


### PR DESCRIPTION
JPA의 이점을 활용하여, 간단하게 프로젝트 DB를 MySQL -> PostgreSQL로 전환 성공.

This closes #59 